### PR TITLE
closes #2, handles case where there is ±0.00 chg_percentage

### DIFF
--- a/finanzen_fundamentals/stocks.py
+++ b/finanzen_fundamentals/stocks.py
@@ -397,7 +397,7 @@ def get_current_value_lxml(stock: str, exchange="TGT", results=[]):
             float(raw_price[0].replace(',', '.')),
             currency,
             float(raw_change[0].replace(',', '.').replace("±","")),
-            float(raw_percentage[0].replace(',', '.')),
+            float(raw_percentage[0].replace(',', '.').replace("±","")),
             time,
             statics.StockMarkets[exchange]['real_name']
         ]


### PR DESCRIPTION
I run the script like once a day, I don't get when exactly the ± happens to the "chg_percent" field, but it seems that it does before the opening of the stock exchange. So when the function was run before 9am I saw the same error on this field.

Ya, writing good test cases for such a dynamic website is a little tricky I guess...