### PR TITLE
Add ETF-Info-Function

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ Note that we use stock names not stock symbols when fetching data. You can searc
 
 This will return the three most matching stock names for your search. You can increase the limit to 30. If you don't give a parameter, all available data will be returned (up to 30).
 
+## Retrive ETF Information
+You can get ETF Infos as dict by calling 
+```import finanzen_fundamentals.etfs as etf```
+After that you can get ETF data by inserting the String after "/etf/".
+```mcsi_world = etf.get_etf_info("amundi-index...")```
+
 ## Alternative Implementation
 Thanks to the contribution of [backster82](https://github.com/backster82), there is also a xml based alternative to the preceeding functions. All of the following functions will return a Pandas DataFrame. Note that get_fundamentals and get_estimates now incorporates the functionallity of the alternative implementation. Hence, you will receive deprecation warning upon using these functions.
 

--- a/finanzen_fundamentals/__init__.py
+++ b/finanzen_fundamentals/__init__.py
@@ -1,2 +1,3 @@
 from . import statics
 from . import stocks
+from . import etfs

--- a/finanzen_fundamentals/etfs.py
+++ b/finanzen_fundamentals/etfs.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# Import Modules
+import re
+import requests
+import warnings
+from finanzen_fundamentals.scraper import _make_soup
+
+# Define Function to Extract ETF Data from finanzen.net
+# Just past URL into Stock-String
+def get_etf_info(stock, output = "dict"):
+    
+    # Parse User Input
+    if output not in ["dict"]:
+        raise ValueError("Only 'dict' supportet for now")
+    
+    # Load Data
+    soup = _make_soup("https://www.finanzen.net/etf/" + stock)
+
+    WKN     = soup.find("span", text="WKN:").next_sibling.strip()
+    ISIN    = soup.find("span", text="ISIN:").next_sibling.strip()
+
+    currentStockTable = soup.find("div", class_="table-responsive quotebox").table
+    currentStockPrice = float(currentStockTable.tr.td.contents[0].replace(",","."))
+    currentStockCurrency = currentStockTable.tr.td.span.contents[0]
+    currentStockExchange = currentStockTable.find("div", class_="quotebox-time").find_next_sibling("div").next_element.strip()
+
+    baseDataTable = soup.find("h2", text="Wichtige Stammdaten").parent
+    baseDataIssuer = baseDataTable.find("div", text="Emittent").parent.a.text
+    baseDataBenchmark = baseDataTable.find("div", text="Benchmark").parent.find("div", {"title": True}).text
+    baseDataFondsSize = float(baseDataTable.find("div", text="Fondsgröße").parent.find("div", {"title": True}).text.replace(".","").replace(",","."))
+
+    info = {
+        "currentStockPrice": currentStockPrice,
+        "currentStockCurrency": currentStockCurrency,
+        "currentStockExchange": currentStockExchange,
+        "WKN": WKN,
+        "ISIN": ISIN,
+        "Issuer": baseDataIssuer,
+        "Benchmark": baseDataBenchmark,
+        "FondsSize": baseDataFondsSize
+    }
+
+    if output == "dict":
+        return info
+
+if __name__ == "__main__":
+    print(get_etf_info("deka-msci-world-etf-de000etfl508"))


### PR DESCRIPTION
For my own need I created a small function which gets the most important ETF data.
Can be extended further, but thats a start which might help others.

I'm not familiar with the __init__.py-Stuff, so I just hope that works.

e.g.:
`mcsi_world = etf.get_etf_info("amundi-index-solutions-amundi-msci-world-etf-c-lu1681043672") `
`{'currentStockPrice': 369.1, 'currentStockCurrency': 'EUR', 'currentStockExchange': 'Berlin', 'WKN': 'A2H59R', 'ISIN': 'LU1681043672', 'Issuer': 'Amundi', 'Benchmark': 'MSCI World', 'FondsSize': 1435173720.05}`